### PR TITLE
fix(dino-game): 修复 CDN 跨域导致 SecurityError 无法游玩

### DIFF
--- a/src/components/auth/dino-game.tsx
+++ b/src/components/auth/dino-game.tsx
@@ -12,7 +12,23 @@ declare global {
 }
 
 const SCRIPT_ID = "auth-dino-bundle"
+const SAFE_STYLE_ID = "auth-dino-safe-style"
 let scriptLoader: Promise<NonNullable<Window["AuthDinoGame"]>> | null = null
+
+function ensureSafeStyleSheet() {
+  if (typeof document === "undefined") {
+    return
+  }
+
+  if (document.getElementById(SAFE_STYLE_ID)) {
+    return
+  }
+
+  const style = document.createElement("style")
+  style.id = SAFE_STYLE_ID
+  // 插入到 <head> 最前面，成为 document.styleSheets[0]，确保同源可访问
+  document.head.insertBefore(style, document.head.firstChild)
+}
 
 function loadDinoGameScript() {
   if (typeof window === "undefined") {
@@ -77,6 +93,9 @@ export function DinoGame() {
     }
 
     host.id = `auth-dino-${hostId}`
+
+    // 确保 document.styleSheets[0] 是同源可访问的样式表，解决 CDN 跨域导致的 SecurityError
+    ensureSafeStyleSheet()
 
     void loadDinoGameScript()
       .then((game) => {


### PR DESCRIPTION
静态资源托管到 CDN 后，登录页恐龙游戏无法游玩。按下空格时抛出 SecurityError: Failed to execute 'insertRule' on 'CSSStyleSheet' 。原因是 auth-dino.bundle.js 在 playIntro() 中调用 document.styleSheets[0].insertRule() 注入 CSS 关键帧动画。CDN 跨域样式表禁止 JS 访问，导致游戏加载中断。

修复方案：  在 DinoGame 组件挂载时，向 <head> 最前面注入一个同源 <style> 元素，确保 document.styleSheets[0] 始终可访问。