### PR TITLE
fix: keep emoji picker open after selecting an emoji

### DIFF
--- a/src/components/message/message-thread-panel.tsx
+++ b/src/components/message/message-thread-panel.tsx
@@ -218,7 +218,6 @@ function MessageThreadPanelContent({
 
     if (!element) {
       setDraft((current) => `${current}${emoji}`)
-      setShowEmojiPanel(false)
       return
     }
 
@@ -227,7 +226,6 @@ function MessageThreadPanelContent({
     const nextDraft = `${draft.slice(0, selectionStart)}${emoji}${draft.slice(selectionEnd)}`
 
     setDraft(nextDraft)
-    setShowEmojiPanel(false)
 
     requestAnimationFrame(() => {
       element.focus()

--- a/src/components/refined-rich-post-editor.tsx
+++ b/src/components/refined-rich-post-editor.tsx
@@ -666,10 +666,7 @@ export function RefinedRichPostEditor({
         panelRef={panels.emojiPanel.panelRef}
         markdownEmojiMap={markdownEmojiMap}
         onClose={panels.emojiPanel.close}
-        onSelect={(shortcode) => {
-          commands.handleEmojiSelect(shortcode)
-          panels.emojiPanel.close()
-        }}
+        onSelect={commands.handleEmojiSelect}
       />
       <ImageInsertPanel
         open={panels.imagePanel.open}


### PR DESCRIPTION
选择表情后 表情窗口保持打开  方便选中多个表情