### PR TITLE
优化 /zones/image 图片分区为瀑布流布局

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1330,16 +1330,52 @@
     }
   }
 
-  .post-gallery-grid {
-    display: grid;
-    align-items: start;
-    gap: 0.5rem;
-    grid-template-columns: repeat(auto-fill, minmax(min(100%, 15.5rem), 1fr));
-  }
+.post-gallery-grid {
+  display: block !important;
+  column-width: 15.5rem;
+  column-gap: 0.75rem;
+}
 
-  .post-gallery-card {
-    width: 100%;
+.post-gallery-card {
+  display: inline-block;
+  width: 100%;
+  margin: 0 0 0.75rem;
+  break-inside: avoid;
+  page-break-inside: avoid;
+  vertical-align: top;
+}
+
+.post-gallery-card img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.post-gallery-card > a > .relative {
+  min-height: 0 !important;
+}
+
+@media (max-width: 640px) {
+  .post-gallery-grid {
+    column-width: auto;
+    column-count: 1;
+    column-gap: 0.75rem;
   }
+}
+
+@media (min-width: 641px) and (max-width: 1023px) {
+  .post-gallery-grid {
+    column-count: 2;
+  }
+}
+
+@media (min-width: 1024px) {
+  .post-gallery-grid {
+    column-width: 15.5rem;
+  }
+}
+
 
   @keyframes toast-in {
     from {


### PR DESCRIPTION
修改的部分

原来的 .post-gallery-grid 使用普通 Grid 布局：

.post-gallery-grid {
  display: grid;
  align-items: start;
  gap: 0.5rem;
  grid-template-columns: repeat(auto-fill, minmax(min(100%, 15.5rem), 1fr));
}

.post-gallery-card {
  width: 100%;
}

这会导致不同高度的图片卡片按行排列，从而产生明显空白。

新增 / 调整的部分

将 .post-gallery-grid 调整为 CSS Columns 瀑布流布局：

.post-gallery-grid {
  display: block !important;
  column-width: 15.5rem;
  column-gap: 0.75rem;
}

为 .post-gallery-card 添加多列布局适配：

.post-gallery-card {
  display: inline-block;
  width: 100%;
  margin: 0 0 0.75rem;
  break-inside: avoid;
  page-break-inside: avoid;
  vertical-align: top;
}

这样可以避免卡片在多列布局中被拆分，并让卡片自然进入瀑布流排列。

同时优化图片显示比例：

.post-gallery-card img {
  display: block;
  width: 100%;
  height: auto;
  object-fit: cover;
}

并移除图片容器的强制最小高度：

.post-gallery-card > a > .relative {
  min-height: 0 !important;
}

这样可以让图片按照自身比例自适应显示，避免被固定高度影响。

响应式适配

本次还增加了响应式布局处理：

@media (max-width: 640px) {
  .post-gallery-grid {
    column-width: auto;
    column-count: 1;
    column-gap: 0.75rem;
  }
}

@media (min-width: 641px) and (max-width: 1023px) {
  .post-gallery-grid {
    column-count: 2;
  }
}

@media (min-width: 1024px) {
  .post-gallery-grid {
    column-width: 15.5rem;
  }
}

对应效果：

移动端：单列显示
平板端：双列显示
桌面端：根据页面宽度自动多列瀑布流显示
解决效果

修改后，/zones/image 页面中的图片卡片可以像 Pinterest 一样根据高度自动错落排列。

相比原来的普通 Grid 布局：

减少了图片卡片之间的大块空白
保持图片原始比例显示
页面整体更加紧凑
图片浏览体验更自然
移动端、平板端、桌面端都有对应适配
测试情况

已完成以下测试：

已执行 pnpm run build，构建成功
已检查 /zones/image 页面显示效果
已确认不同高度图片卡片可以正常自适应排列
已确认页面不再出现明显的大块空白区域
已确认移动端、平板端和桌面端布局表现正常