### PR TITLE
fix(upload): use integer keys for PostgreSQL advisory lock

### DIFF
--- a/src/lib/user-upload-quota.ts
+++ b/src/lib/user-upload-quota.ts
@@ -121,7 +121,10 @@ export async function createUploadWithinDailyQuota(input: {
   try {
     return await prisma.$transaction(async (tx) => {
       await tx.$executeRaw`
-        SELECT pg_advisory_xact_lock(${input.userId}, ${getUtcDayLockKey(now)})
+        SELECT pg_advisory_xact_lock(
+          ${input.userId}::integer,
+          ${getUtcDayLockKey(now)}::integer
+        )
       `
 
       const existing = await tx.upload.findUnique({

--- a/test/database-concurrency-boundaries.test.ts
+++ b/test/database-concurrency-boundaries.test.ts
@@ -74,3 +74,16 @@ test("redeem code claiming is conditional and category limits are serialized", a
     "the same user/category must be locked before its redeemed-code count is read",
   )
 })
+
+test("daily upload quota uses PostgreSQL's two-integer advisory lock signature", async () => {
+  const source = await readSource("src/lib/user-upload-quota.ts")
+
+  assert.match(
+    source,
+    /pg_advisory_xact_lock\(\s*\$\{input\.userId\}::integer,\s*\$\{getUtcDayLockKey\(now\)\}::integer\s*\)/,
+  )
+  assert.doesNotMatch(
+    source,
+    /pg_advisory_xact_lock\(\$\{input\.userId\},\s*\$\{getUtcDayLockKey\(now\)\}\)/,
+  )
+})


### PR DESCRIPTION
## 问题

上传配额事务执行双参数 advisory lock 时，Prisma 将两个 JavaScript 数字参数绑定为 `bigint`：

```sql
SELECT pg_advisory_xact_lock($1, $2)
```

PostgreSQL 不存在 `pg_advisory_xact_lock(bigint, bigint)`，导致 `/api/upload` 返回 500，并产生以下错误：

```
P2010 / 42883
function pg_advisory_xact_lock(bigint, bigint) does not exist
```

PostgreSQL 支持的签名是单个 `bigint`，或者两个 `integer`。

参考文档：
https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS

## 修改

- 将用户 ID 和 UTC 日期锁键显式转换为 `integer`
- 增加回归测试，防止双参数锁恢复为未转换的参数
- 不改变上传配额、去重逻辑或事务范围

## 验证

- `pnpm run typegen`：通过
- `tsc --noEmit`：通过
- `pnpm run lint`：通过
- `pnpm run test`：98 项全部通过
- 已在 PostgreSQL 生产部署中验证图片上传恢复正常