### PR TITLE
feat(addons): add upload transform provider hook

### DIFF
--- a/docs/插件系统开发文档.md
+++ b/docs/插件系统开发文档.md
@@ -82,7 +82,7 @@
 | Markdown / 选择器表情扩展 | **部分支持** | `emoji provider` | 已支持 `emoji` provider 注入 Markdown 短码表情，站点渲染和编辑器 / 私信表情面板会复用 |
 | 替换发帖编辑器 / 评论编辑器 | **部分支持** | `editor provider` | 宿主已接入 `editor` provider，可按场景替换 `post` / `comment` 等编辑器，默认编辑器仍作为 fallback |
 | 给现有编辑器工具栏追加按钮 | **部分支持** | `editor provider.toolbarItems` | 默认 `RefinedRichPostEditor` 已支持通过 `toolbarItems` 追加按钮；整块替换后的自定义编辑器是否复用这套按钮，由对应 provider 自行决定 |
-| 替换系统图片上传接口 | **部分支持** | `upload provider` | 已支持插件接管 `/api/upload` 和站点图标上传；插件未处理当前文件时，宿主继续回退到内置 local / s3 上传 |
+| 处理或替换系统图片上传 | **已支持** | `upload provider` | `transformFile()` 可串行压缩、缩放或转码，`uploadFile()` 可接管最终存储；插件未处理当前文件时，宿主继续回退到内置 local / s3 上传 |
 | 插件主动保存文件到系统存储 | **已支持** | `context.files.save()` | 插件可把生成图、导出文件等交给宿主上传存储，复用后台配置的本地 / S3 / OSS / COS，不需要插件单独配置存储 |
 | 替换系统短信发送接口 | **已支持** | `sms provider` | 插件注册 `kind: "sms"` provider 后，可通过 `send()` 接管短信投递；如同时实现 `sendVerificationCode()` 与 `verifyVerificationCode()`，可完整接管手机注册、短信登录、绑定手机、手机找回密码等验证码生成 / 发送 / 校验；未命中插件时回退宿主内置验证码与阿里云短信 |
 | 替换宿主已有页面区块 | **已支持** | `surface` | 宿主继续负责数据加载和页面骨架，插件只决定该区块渲染宿主默认 UI，还是渲染插件实现 |
@@ -1671,7 +1671,34 @@ api.registerProvider({
 
 当前 upload provider runtime 已接入的能力包括：
 
+- `transformFile(input)`：在水印完成后、哈希去重与存储前改写图片内容；返回 `{ buffer: Uint8Array }`，返回 `null` 时跳过当前 provider
 - `uploadFile(input)`：尝试处理当前上传请求
+
+其中 `transformFile()` 按 provider 顺序串行执行，适合压缩、缩放和格式转换。宿主会在每次转换后重新检测真实 MIME、文件大小和 SHA-256，转换后的图片仍继续走原有配额、去重与 local / S3 存储。`uploadFile()` 仍用于完整接管最终存储；只做图片处理的插件不应在 `transformFile()` 内调用 `context.files.save()`，避免重新进入上传转换链路。
+
+示例：
+
+```js
+api.registerProvider({
+  kind: "upload",
+  code: "image-compressor",
+  label: "图片压缩",
+  order: -100,
+  data: {
+    runtime: {
+      async transformFile({ context, preparedFile, folder }) {
+        const settings = await context.readConfig("settings", {})
+        if (!settings.enabled || folder === "avatars" || !preparedFile.buffer) {
+          return null
+        }
+
+        const compressed = await compressImage(preparedFile.buffer, settings)
+        return compressed ? { buffer: compressed } : null
+      },
+    },
+  },
+})
+```
 
 上传 runtime 输入里当前可用的重点字段：
 
@@ -1687,7 +1714,8 @@ api.registerProvider({
 
 当前宿主行为：
 
-- `/api/upload` 与站点图标上传都会先尝试 `upload provider`
+- 图片正文、私信图片、图片附件、远程图片本地化和后台图片素材都会进入 upload provider 转换阶段
+- 所有 `transformFile()` 会先按 provider 顺序串行执行，之后才尝试 `uploadFile()` 存储接管
 - provider 返回 `null` / `undefined` 时，宿主继续回退到内置 local / s3 上传
 - provider 返回上传结果时，宿主继续复用现有去重、入库、日志流程
 - 帖子附件上传也会经过同一调度层，但插件可以按 `folder` 或 MIME 类型选择跳过，让宿主继续使用本地 / s3

--- a/src/addons-host/runtime/files.ts
+++ b/src/addons-host/runtime/files.ts
@@ -188,6 +188,7 @@ export async function saveAddonFile(
 
   const preparedFile = await prepareUploadedFile(file, {
     folder,
+    maxFileSizeBytes: maxSizeMb * 1024 * 1024,
     settings,
   })
   ensureAllowedExtension(file.name, preparedFile.detectedMime, allowedExtensions)

--- a/src/addons-host/sdk/server.ts
+++ b/src/addons-host/sdk/server.ts
@@ -166,6 +166,7 @@ export type {
   AddonUploadPreparedFile,
   AddonUploadProviderRuntimeHooks,
   AddonUploadProviderSaveResult,
+  AddonUploadProviderTransformResult,
 } from "@/addons-host/upload-types"
 export type {
   AddonHomeFeedProviderMetadata,

--- a/src/addons-host/upload-types.ts
+++ b/src/addons-host/upload-types.ts
@@ -29,6 +29,10 @@ export interface AddonUploadProviderSaveResult {
   fileHash?: string
 }
 
+export interface AddonUploadProviderTransformResult {
+  buffer: Uint8Array
+}
+
 interface AddonUploadProviderRuntimeBaseInput {
   addon: LoadedAddonRuntime
   provider: AddonProviderRegistration
@@ -41,6 +45,11 @@ interface AddonUploadProviderRuntimeBaseInput {
 }
 
 export interface AddonUploadProviderRuntimeHooks {
+  transformFile?: (
+    input: AddonUploadProviderRuntimeBaseInput,
+  ) => AddonMaybePromise<
+    AddonUploadProviderTransformResult | null | undefined
+  >
   uploadFile?: (
     input: AddonUploadProviderRuntimeBaseInput,
   ) => AddonMaybePromise<

--- a/src/app/api/admin/site-settings/icon-upload/route.ts
+++ b/src/app/api/admin/site-settings/icon-upload/route.ts
@@ -39,7 +39,18 @@ export const POST = createAdminRouteHandler(async ({ request, adminUser }) => {
     apiError(400, `上传文件不能超过 ${maxSizeMb}MB`)
   }
 
-  const preparedFile = await prepareUploadedFile(file)
+  const preparedFile = await prepareUploadedFile(file, {
+    folder: "icon",
+    maxFileSizeBytes: maxSizeBytes,
+    settings,
+    request,
+    actor: {
+      id: adminUser.id,
+      username: adminUser.username,
+      role: adminUser.role,
+      kind: "admin",
+    },
+  })
 
   if (!isAllowedUploadMimeType(preparedFile.detectedMime, ALLOWED_SITE_ICON_EXTENSIONS)) {
     apiError(400, `仅支持上传 ${ALLOWED_SITE_ICON_EXTENSIONS.join(" / ")} 格式的站点图标`)

--- a/src/app/api/admin/site-settings/markdown-emoji/upload/route.ts
+++ b/src/app/api/admin/site-settings/markdown-emoji/upload/route.ts
@@ -59,7 +59,15 @@ export const POST = createAdminRouteHandler(async ({ request, adminUser }) => {
 
     const preparedFile = await prepareUploadedFile(file, {
       folder: MARKDOWN_EMOJI_UPLOAD_FOLDER,
+      maxFileSizeBytes: maxSizeBytes,
       settings,
+      request,
+      actor: {
+        id: adminUser.id,
+        username: adminUser.username,
+        role: adminUser.role,
+        kind: "admin",
+      },
     })
 
     if (!isAllowedUploadMimeType(preparedFile.detectedMime, MARKDOWN_EMOJI_UPLOAD_IMAGE_EXTENSIONS)) {

--- a/src/app/api/admin/site-settings/watermark-logo-upload/route.ts
+++ b/src/app/api/admin/site-settings/watermark-logo-upload/route.ts
@@ -44,7 +44,18 @@ export const POST = createAdminRouteHandler(async ({ request, adminUser }) => {
     apiError(400, `水印图片不能超过 ${maxSizeMb}MB`)
   }
 
-  const preparedFile = await prepareUploadedFile(file)
+  const preparedFile = await prepareUploadedFile(file, {
+    folder: WATERMARK_LOGO_FOLDER,
+    maxFileSizeBytes: maxSizeBytes,
+    settings,
+    request,
+    actor: {
+      id: adminUser.id,
+      username: adminUser.username,
+      role: adminUser.role,
+      kind: "admin",
+    },
+  })
 
   if (!isAllowedUploadMimeType(preparedFile.detectedMime, WATERMARK_LOGO_EXTENSIONS)) {
     apiError(400, `仅支持上传 ${WATERMARK_LOGO_EXTENSIONS.join(" / ")} 格式的水印图片`)

--- a/src/app/api/attachments/upload/route.ts
+++ b/src/app/api/attachments/upload/route.ts
@@ -60,7 +60,17 @@ export const POST = createUserRouteHandler(async ({ request, currentUser }) => {
         apiError(400, `附件大小不能超过 ${settings.attachmentMaxFileSizeMb}MB`)
       }
 
-      const preparedFile = await prepareBinaryUploadedFile(file)
+      const preparedFile = await prepareBinaryUploadedFile(file, {
+        folder: "attachments",
+        maxFileSizeBytes: maxSizeBytes,
+        settings,
+        request,
+        actor: {
+          id: currentUser.id,
+          username: currentUser.username,
+          kind: "user",
+        },
+      })
       const requestUrl = new URL(request.url)
       const hookCtx = { request, pathname: requestUrl.pathname, searchParams: requestUrl.searchParams }
       await executeAddonActionHook("upload.file.before", {

--- a/src/app/api/messages/upload/route.ts
+++ b/src/app/api/messages/upload/route.ts
@@ -69,7 +69,14 @@ export const POST = createUserRouteHandler<MessageUploadResponse>(async ({ reque
 
         const preparedFile = await prepareUploadedFile(file, {
           folder: MESSAGE_IMAGE_UPLOAD_FOLDER,
+          maxFileSizeBytes: maxSizeBytes,
           settings,
+          request,
+          actor: {
+            id: currentUser.id,
+            username: currentUser.username,
+            kind: "user",
+          },
         })
 
         if (!isAllowedUploadMimeType(preparedFile.detectedMime, allowedImageExtensions)) {

--- a/src/app/api/upload/remote-image/route.ts
+++ b/src/app/api/upload/remote-image/route.ts
@@ -198,7 +198,14 @@ export const POST = createUserRouteHandler(async ({ request, currentUser }) => {
   })
   const preparedFile = await prepareUploadedFile(file, {
     folder,
+    maxFileSizeBytes: maxSizeBytes,
     settings,
+    request,
+    actor: {
+      id: currentUser.id,
+      username: currentUser.username,
+      kind: "user",
+    },
   })
 
   if (!isAllowedUploadMimeType(preparedFile.detectedMime, allowedExtensions)) {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -60,7 +60,14 @@ export const POST = createUserRouteHandler(async ({ request, currentUser }) => {
 
       const preparedFile = await prepareUploadedFile(file, {
         folder,
+        maxFileSizeBytes: maxSizeBytes,
         settings,
+        request,
+        actor: {
+          id: currentUser.id,
+          username: currentUser.username,
+          kind: "user",
+        },
       })
 
       if (!isAllowedUploadMimeType(preparedFile.detectedMime, allowedExtensions)) {

--- a/src/lib/addon-upload-providers.ts
+++ b/src/lib/addon-upload-providers.ts
@@ -6,6 +6,7 @@ import type {
   AddonUploadActor,
   AddonUploadPreparedFile,
   AddonUploadProviderRuntimeHooks,
+  AddonUploadProviderTransformResult,
 } from "@/addons-host/upload-types"
 import {
   invokeAddonProviderRuntime,
@@ -19,6 +20,73 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function normalizeOptionalString(value: unknown, fallback = "") {
   return typeof value === "string" ? value.trim() : fallback
+}
+
+function normalizeTransformBuffer(value: unknown) {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const buffer = value.buffer
+  if (buffer instanceof Uint8Array && buffer.byteLength > 0) {
+    return buffer
+  }
+
+  return null
+}
+
+export async function transformWithAddonUploadProviders(input: {
+  request?: Request
+  actor?: AddonUploadActor | null
+  file: File
+  preparedFile: AddonUploadPreparedFile
+  folder: string
+  normalizeTransformedFile: (
+    result: AddonUploadProviderTransformResult,
+  ) => AddonUploadPreparedFile | Promise<AddonUploadPreparedFile>
+}): Promise<AddonUploadPreparedFile> {
+  const providers = await listAddonProviderRuntimeItems<AddonUploadProviderRuntimeHooks>(
+    "upload",
+    input.request ? { request: input.request } : undefined,
+  )
+  let preparedFile = input.preparedFile
+
+  for (const item of providers) {
+    const runtime = item.runtime
+    if (typeof runtime?.transformFile !== "function") {
+      continue
+    }
+
+    const output = await invokeAddonProviderRuntime(
+      item,
+      "transformFile",
+      () => ({
+        addon: item.addon,
+        provider: item.provider,
+        context: item.context,
+        request: input.request,
+        actor: input.actor,
+        file: input.file,
+        preparedFile,
+        folder: input.folder,
+      }),
+    )
+
+    if (typeof output === "undefined" || output === null) {
+      continue
+    }
+
+    const buffer = normalizeTransformBuffer(output)
+    if (!buffer) {
+      throw new Error(
+        `addon upload provider "${item.provider.code}" returned an invalid transform result`,
+      )
+    }
+
+    preparedFile = await input.normalizeTransformedFile({ buffer })
+  }
+
+  return preparedFile
 }
 
 function resolveFallbackFileName(urlPath: string, folder: string, preparedFile: AddonUploadPreparedFile, originalName: string) {

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -13,7 +13,10 @@ import { normalizeUploadProvider } from "@/lib/upload-provider"
 import { buildUploadStoragePath } from "@/lib/upload-path"
 import { getPrimaryUploadExtensionForMimeType, getUploadMimeType } from "@/lib/upload-rules"
 import { applyTextWatermarkToBuffer } from "@/lib/watermark-lib.server"
-import { saveWithAddonUploadProvider } from "@/lib/addon-upload-providers"
+import {
+  saveWithAddonUploadProvider,
+  transformWithAddonUploadProviders,
+} from "@/lib/addon-upload-providers"
 import type { AddonUploadActor } from "@/addons-host/upload-types"
 import { resolveWatermarkLogoBuffer } from "@/lib/watermark-logo.server"
 
@@ -37,6 +40,12 @@ export interface PreparedUploadFile {
 export interface SaveUploadedFileOptions {
   request?: Request
   actor?: AddonUploadActor | null
+}
+
+export interface PrepareUploadedFileOptions extends SaveUploadedFileOptions {
+  folder?: string
+  maxFileSizeBytes?: number
+  settings?: WatermarkUploadSettings
 }
 
 type UploadSettings = Awaited<ReturnType<typeof getServerSiteSettings>>
@@ -244,10 +253,25 @@ async function computeFileHash(file: File) {
 /**
  * 单次读取整文件，复用同一块 Buffer 完成哈希计算、类型检测和后续写盘。
  */
-export async function prepareUploadedFile(file: File, options?: {
-  folder?: string
-  settings?: WatermarkUploadSettings
-}): Promise<PreparedUploadFile> {
+function prepareImageBuffer(buffer: Buffer): PreparedUploadFile {
+  const detectedMime = detectMimeTypeFromBytes(buffer.subarray(0, 12)) ?? detectSvgMimeType(buffer)
+
+  if (!detectedMime || !IMAGE_MIME_TYPES.has(detectedMime)) {
+    throw new Error("图片处理插件返回了不受支持的图片格式")
+  }
+
+  return {
+    buffer,
+    fileHash: createHash("sha256").update(buffer).digest("hex"),
+    detectedMime,
+    fileSize: buffer.byteLength,
+  }
+}
+
+export async function prepareUploadedFile(
+  file: File,
+  options?: PrepareUploadedFileOptions,
+): Promise<PreparedUploadFile> {
   const sourceBuffer = await readFileStreamToBuffer(file)
   const detectedMime = detectMimeTypeFromBytes(sourceBuffer.subarray(0, 12)) ?? detectSvgMimeType(sourceBuffer)
 
@@ -262,11 +286,28 @@ export async function prepareUploadedFile(file: File, options?: {
     settings: options?.settings,
   })
 
+  const preparedFile = prepareImageBuffer(buffer)
+  const transformedFile = await transformWithAddonUploadProviders({
+    request: options?.request,
+    actor: options?.actor,
+    file,
+    preparedFile,
+    folder: options?.folder || "avatars",
+    normalizeTransformedFile: ({ buffer: transformedBuffer }) => (
+      prepareImageBuffer(Buffer.from(transformedBuffer))
+    ),
+  })
+
+  if (
+    options?.maxFileSizeBytes
+    && transformedFile.fileSize > options.maxFileSizeBytes
+  ) {
+    throw new Error("图片处理后的文件大小超过站点上传限制")
+  }
+
   return {
-    buffer,
-    fileHash: createHash("sha256").update(buffer).digest("hex"),
-    detectedMime,
-    fileSize: buffer.byteLength,
+    ...transformedFile,
+    buffer: transformedFile.buffer ? Buffer.from(transformedFile.buffer) : null,
   }
 }
 
@@ -312,7 +353,18 @@ async function saveToLocal(
   }
 }
 
-export async function prepareBinaryUploadedFile(file: File): Promise<PreparedUploadFile> {
+export async function prepareBinaryUploadedFile(
+  file: File,
+  options?: PrepareUploadedFileOptions,
+): Promise<PreparedUploadFile> {
+  const headerBuffer = Buffer.from(await file.slice(0, 4096).arrayBuffer())
+  const detectedImageMime = detectMimeTypeFromBytes(headerBuffer.subarray(0, 12))
+    ?? detectSvgMimeType(headerBuffer)
+
+  if (detectedImageMime && IMAGE_MIME_TYPES.has(detectedImageMime)) {
+    return prepareUploadedFile(file, options)
+  }
+
   return {
     buffer: null,
     fileHash: await computeFileHash(file),


### PR DESCRIPTION
## 背景

现有 upload provider 的 `uploadFile()` 可以由插件完整接管文件存储，但插件无法在继续使用宿主内置 local / S3 存储的前提下，仅对上传图片进行压缩、缩放或格式转换。

这使图片处理类插件必须重复实现存储逻辑，也无法自然复用宿主现有的文件配额、内容去重和上传记录。

## 修改

- 为 upload provider 增加可选的 `transformFile()` runtime hook
- 按 provider 顺序串行执行图片转换
- 转换发生在水印处理之后、哈希去重和最终存储之前
- 每次转换后重新检测真实 MIME、文件大小和 SHA-256
- 转换完成后继续使用现有的配额、去重及 local / S3 存储流程
- 转换后的文件重新检查站点上传大小限制
- 将转换阶段接入以下上传场景：
  - 正文及评论图片
  - 私信图片
  - 图片附件
  - 远程图片本地化
  - 站点图标
  - Markdown 表情
  - 水印 Logo
  - 插件主动保存的图片
- 更新插件开发文档并增加 `transformFile()` 示例

## 兼容性

`transformFile()` 是可选钩子。

未实现该钩子的现有 upload provider 行为不变；provider 返回 `null` 或 `undefined` 时会跳过当前转换并继续原有流程。现有 `uploadFile()` 存储接管能力保持不变。

## 验证

- Next.js 类型生成通过
- TypeScript 类型检查通过
- ESLint 检查通过
- 测试通过：97 passed，0 failed
- Next.js 生产构建成功
- 已通过图片自动压缩插件验证转换、上传与后台配置流程