### PR TITLE
修复 AI 标签辅助失败时阻断发帖的问题

### DIFF
--- a/src/components/post/use-create-post-ai-assist.ts
+++ b/src/components/post/use-create-post-ai-assist.ts
@@ -126,6 +126,13 @@ export function resolveAiSuggestionNeeds(params: {
   }
 }
 
+export function shouldContinueAfterAiSuggestionError(params: {
+  needBoard: boolean
+  needTags: boolean
+}) {
+  return !params.needBoard && params.needTags
+}
+
 function mergeSuggestedTagsIntoDraft(draft: LocalPostDraft, tags: AiCategorizeTagLite[]) {
   if (tags.length === 0) {
     return draft
@@ -398,6 +405,9 @@ export function useCreatePostAiAssist({
       setAiSuggestedBoard(null)
       setAiSuggestedTags([])
       setAiSuggestionError(error instanceof Error ? error.message : "AI 建议生成失败")
+      if (shouldContinueAfterAiSuggestionError({ needBoard, needTags })) {
+        return currentDraft
+      }
       throw error
     } finally {
       setAiSuggestionPending(false)

--- a/test/ai-post-assist-boundaries.test.ts
+++ b/test/ai-post-assist-boundaries.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  resolveAiSuggestionNeeds,
+  shouldContinueAfterAiSuggestionError,
+} from "../src/components/post/use-create-post-ai-assist"
+
+test("AI tag extraction failures remain optional when board selection is manual", () => {
+  const tagOnlyNeeds = resolveAiSuggestionNeeds({
+    canUseAutoBoardSelection: false,
+    canUseAiTagExtraction: true,
+    boardSelectionMode: "manual",
+  })
+
+  assert.deepEqual(tagOnlyNeeds, {
+    needBoard: false,
+    needTags: true,
+  })
+  assert.equal(shouldContinueAfterAiSuggestionError(tagOnlyNeeds), true)
+})
+
+test("AI board selection failures still block until a board is available", () => {
+  const boardNeeds = resolveAiSuggestionNeeds({
+    canUseAutoBoardSelection: true,
+    canUseAiTagExtraction: true,
+    boardSelectionMode: "auto",
+  })
+
+  assert.deepEqual(boardNeeds, {
+    needBoard: true,
+    needTags: true,
+  })
+  assert.equal(shouldContinueAfterAiSuggestionError(boardNeeds), false)
+})
+
+test("manual fallback skips AI entirely when board auto-selection is available", () => {
+  assert.deepEqual(resolveAiSuggestionNeeds({
+    canUseAutoBoardSelection: true,
+    canUseAiTagExtraction: true,
+    boardSelectionMode: "manual",
+  }), {
+    needBoard: false,
+    needTags: false,
+  })
+})


### PR DESCRIPTION
## 修改内容

- AI 自动提取标签失败时，不再阻断用户正常发帖
- 保留 AI 自动选节点失败时的阻断逻辑，因为发帖必须有节点
- 增加 AI 发帖辅助边界测试

## 背景

当仅开启 AI 标签提取时，如果模型服务临时不可用，发帖流程不应该失败。标签只是辅助能力，失败后应允许用户继续提交帖子。

## 验证

- pnpm test
- pnpm typecheck
- pnpm lint