### PR TITLE
修复：在画廊信息流中保留侧边栏

### DIFF
--- a/src/app/boards/[slug]/page.tsx
+++ b/src/app/boards/[slug]/page.tsx
@@ -21,7 +21,6 @@ import { buildAddonHookSearchParams, buildHookedPostStreamDisplayItems } from "@
 import { DEFAULT_TAXONOMY_POST_SORT, normalizeTaxonomyPostSort, type TaxonomyPostSort } from "@/lib/forum-taxonomy-sort"
 import { getHomeSidebarHotTopics, resolveSidebarUser } from "@/lib/home-sidebar"
 import { POST_LIST_LOAD_MODE_INFINITE } from "@/lib/post-list-load-mode"
-import { POST_LIST_DISPLAY_MODE_GALLERY } from "@/lib/post-list-display"
 import { DEFAULT_ALLOWED_POST_TYPES, normalizePostTypes } from "@/lib/post-types"
 import { readSearchParam } from "@/lib/search-params"
 import { buildMetadataKeywords } from "@/lib/seo"
@@ -197,7 +196,6 @@ export default async function BoardPage(props: PageProps<"/boards/[slug]">) {
     featuredHref: buildBoardPageHref(params.slug, 1, "featured"),
   }
   const boardPostsApiPath = buildBoardPostsApiPath(params.slug, currentSort)
-  const shouldShowRightSidebar = board.postListDisplayMode !== POST_LIST_DISPLAY_MODE_GALLERY
 
 
 
@@ -279,7 +277,7 @@ export default async function BoardPage(props: PageProps<"/boards/[slug]">) {
             </div>
             </main>
           )}
-          rightSidebar={shouldShowRightSidebar ? (
+          rightSidebar={(
             <aside className="mt-6 hidden pb-12 lg:block">
               <AddonSlotRenderer slot="board.sidebar.before" />
               <AddonSurfaceRenderer surface="board.sidebar" props={{ announcements, board, hotTopics, moderators: moderatorGroups.boardModerators, zoneModerators: moderatorGroups.zoneModerators, settings }}>
@@ -302,7 +300,7 @@ export default async function BoardPage(props: PageProps<"/boards/[slug]">) {
               </AddonSurfaceRenderer>
               <AddonSlotRenderer slot="board.sidebar.after" />
             </aside>
-          ) : null}
+          )}
         />
         </AddonSurfaceRenderer>
         <AddonSlotRenderer slot="board.page.after" />

--- a/src/app/home-feed-page.tsx
+++ b/src/app/home-feed-page.tsx
@@ -49,7 +49,6 @@ import {
 import { getHomeSidebarHotTopics } from "@/lib/home-sidebar"
 import { groupHomeSidebarPanels } from "@/lib/home-sidebar-layout"
 import { getHomeSidebarStats } from "@/lib/home-sidebar-stats"
-import { POST_LIST_DISPLAY_MODE_GALLERY } from "@/lib/post-list-display"
 import { POST_LIST_LOAD_MODE_INFINITE } from "@/lib/post-list-load-mode"
 import {
   attachPostListTipSummaries,
@@ -312,7 +311,6 @@ export async function HomeFeedPage({
         ]
       : [],
   )
-  const shouldShowRightSidebar = settings.homeFeedPostListDisplayMode !== POST_LIST_DISPLAY_MODE_GALLERY
 
   const sortBeforeSlot =
     currentSort === "new"
@@ -491,7 +489,7 @@ export async function HomeFeedPage({
                 {currentSort ? <AddonSlotRenderer slot={sortAfterSlot} props={feedSlotProps} /> : null}
               </div>
             )}
-            rightSidebar={shouldShowRightSidebar ? (
+            rightSidebar={(
               <div className="mt-6 hidden pb-12 lg:block">
                 <AddonSlotRenderer slot="feed.sidebar.before" props={feedSlotProps} />
                 <AddonSurfaceRenderer
@@ -527,7 +525,7 @@ export async function HomeFeedPage({
                 </AddonSurfaceRenderer>
                 <AddonSlotRenderer slot="feed.sidebar.after" props={feedSlotProps} />
               </div>
-            ) : null}
+            )}
           />
         </AddonSurfaceRenderer>
         <AddonSlotRenderer slot="feed.page.after" props={feedSlotProps} />

--- a/src/app/zones/[slug]/page.tsx
+++ b/src/app/zones/[slug]/page.tsx
@@ -19,7 +19,6 @@ import { buildAddonHookSearchParams, buildHookedPostStreamDisplayItems } from "@
 import { DEFAULT_TAXONOMY_POST_SORT, normalizeTaxonomyPostSort, type TaxonomyPostSort } from "@/lib/forum-taxonomy-sort"
 import { getHomeSidebarHotTopics, resolveSidebarUser } from "@/lib/home-sidebar"
 
-import { POST_LIST_DISPLAY_MODE_GALLERY } from "@/lib/post-list-display"
 import { DEFAULT_ALLOWED_POST_TYPES } from "@/lib/post-types"
 import { POST_LIST_LOAD_MODE_INFINITE } from "@/lib/post-list-load-mode"
 import { readSearchParam } from "@/lib/search-params"
@@ -165,7 +164,6 @@ export default async function ZonePage(props: PageProps<"/zones/[slug]">) {
     featuredHref: buildZonePageHref(params.slug, 1, "featured"),
   }
   const zonePostsApiPath = buildZonePostsApiPath(params.slug, currentSort)
-  const shouldShowRightSidebar = zone.postListDisplayMode !== POST_LIST_DISPLAY_MODE_GALLERY
   const zoneSlotProps = {
     zoneId: zone.id,
     zoneSlug: zone.slug,
@@ -274,7 +272,7 @@ export default async function ZonePage(props: PageProps<"/zones/[slug]">) {
               </div>
               </main>
             )}
-            rightSidebar={shouldShowRightSidebar ? (
+            rightSidebar={(
               <aside className="mt-6 hidden pb-12 lg:block">
               <AddonSlotRenderer slot="zone.sidebar.before" props={zoneSlotProps} />
               <AddonSurfaceRenderer surface="zone.sidebar" props={zoneSlotProps}>
@@ -293,7 +291,7 @@ export default async function ZonePage(props: PageProps<"/zones/[slug]">) {
               </AddonSurfaceRenderer>
               <AddonSlotRenderer slot="zone.sidebar.after" props={zoneSlotProps} />
               </aside>
-            ) : null}
+            )}
           />
         </AddonSurfaceRenderer>
         <AddonSlotRenderer slot="zone.page.after" props={zoneSlotProps} />

--- a/test/gallery-sidebar-layout.test.ts
+++ b/test/gallery-sidebar-layout.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import test from "node:test"
+
+const root = process.cwd()
+
+async function readSource(relativePath: string) {
+  return readFile(path.join(root, relativePath), "utf8")
+}
+
+test("gallery list pages keep the right sidebar mounted", async () => {
+  const pages = [
+    ["src/app/home-feed-page.tsx", "feed.sidebar"],
+    ["src/app/boards/[slug]/page.tsx", "board.sidebar"],
+    ["src/app/zones/[slug]/page.tsx", "zone.sidebar"],
+  ] as const
+
+  for (const [file, sidebarSurface] of pages) {
+    const source = await readSource(file)
+
+    assert.match(source, /rightSidebar=\{\(/, `${file} should always provide rightSidebar content`)
+    assert.match(source, new RegExp(`surface=\"${sidebarSurface}\"`), `${file} should keep the sidebar addon surface mounted`)
+    assert.doesNotMatch(source, /rightSidebar=\{shouldShowRightSidebar \?/, `${file} should not hide the sidebar in gallery mode`)
+    assert.doesNotMatch(source, /postListDisplayMode\s*!==\s*POST_LIST_DISPLAY_MODE_GALLERY/, `${file} should not use gallery mode to disable the sidebar`)
+  }
+})
+
+test("desktop shell keeps a three-column layout when a right sidebar exists", async () => {
+  const css = await readSource("src/app/globals.css")
+
+  assert.match(css, /grid-template-columns:\s*200px minmax\(0, 1fr\) 250px;/)
+  assert.match(css, /grid-template-columns:\s*60px minmax\(0, 1fr\) 250px;/)
+  assert.match(css, /data-has-right-sidebar='false'[\s\S]*?grid-template-columns:\s*200px minmax\(0, 1fr\);/)
+})


### PR DESCRIPTION
## 修改内容

- 基于issue #28做的修复
- 首页画廊模式下保留右侧栏，不再因为画廊模式隐藏侧边栏
- 节点页、分区页画廊模式同样保留右侧栏
- 增加画廊布局边界测试，确保右侧栏内容持续挂载

## 背景

当前版本启用画廊模式后，页面会根据 `POST_LIST_DISPLAY_MODE_GALLERY` 主动隐藏右侧栏，导致桌面端布局右侧留空，帖子卡片横向显示过多列，阅读体验变差。

## 验证

- pnpm test
- pnpm typecheck
- pnpm lint