### PR TITLE
修复首页最新列表时间显示与排序不一致的问题

### DIFF
--- a/src/lib/addon-feed-posts.ts
+++ b/src/lib/addon-feed-posts.ts
@@ -181,7 +181,9 @@ export async function buildHookedFeedDisplayItems(input: {
     })
     const rewardConfig = parsePostRewardPoolConfigFromContent(post.content)
     const publishedAtRaw = resolveAddonPostDate(post.publishedAt, post.createdAt) ?? post.createdAt
+    const activityAtRaw = resolveAddonPostDate(post.activityAt, post.lastCommentedAt ?? publishedAtRaw) ?? publishedAtRaw
     const lastRepliedAtRaw = resolveAddonPostDate(post.lastCommentedAt, post.publishedAt ?? post.createdAt) ?? publishedAtRaw
+    const useActivityTime = input.sort === "latest" || input.sort === "following" || input.sort === "featured"
     const commentHeat = resolvePostHeatStyle({
       views: post.viewCount,
       comments: post.commentCount,
@@ -228,8 +230,8 @@ export async function buildHookedFeedDisplayItems(input: {
       authorNameClassName: getVipNameClass(authorIsVip, authorVipLevel, { emphasize: true }),
       metaPrimary: input.sort === "new"
         ? formatRelativeTime(publishedAtRaw)
-        : formatRelativeTime(lastRepliedAtRaw),
-      metaPrimaryRaw: input.sort === "new" ? publishedAtRaw : lastRepliedAtRaw,
+        : formatRelativeTime(useActivityTime ? activityAtRaw : lastRepliedAtRaw),
+      metaPrimaryRaw: input.sort === "new" ? publishedAtRaw : (useActivityTime ? activityAtRaw : lastRepliedAtRaw),
       metaSecondary: (
         input.sort === "latest"
         || input.sort === "new"

--- a/src/lib/forum-feed-display.ts
+++ b/src/lib/forum-feed-display.ts
@@ -72,6 +72,31 @@ function resolveGalleryCoverImage(coverImage: string | null | undefined, preview
   return previewMedia?.type === "image" ? previewMedia.src : null
 }
 
+function shouldUseActivityTimeForFeedSort(sort: FeedSort) {
+  return sort === "latest" || sort === "following" || sort === "featured"
+}
+
+export function resolveFeedPrimaryTime(item: ForumFeedItem, currentSort: FeedSort) {
+  if (currentSort === "new") {
+    return {
+      label: item.publishedAt,
+      raw: item.publishedAtRaw,
+    }
+  }
+
+  if (shouldUseActivityTimeForFeedSort(currentSort)) {
+    return {
+      label: item.activityAt,
+      raw: item.activityAtRaw,
+    }
+  }
+
+  return {
+    label: item.lastRepliedAt,
+    raw: item.lastRepliedAtRaw,
+  }
+}
+
 export function getFeedPinLabel(pinScope?: string | null) {
   if (pinScope === "GLOBAL") {
     return "全局置顶"
@@ -96,6 +121,7 @@ export function mapForumFeedItemsToDisplayItems(
     const authorIsVip = isVipActive({ vipLevel: item.authorVipLevel, vipExpiresAt: item.authorVipExpiresAt })
 
     const contentMarkdown = typeof item.contentMarkdown === "string" ? item.contentMarkdown : ""
+    const primaryTime = resolveFeedPrimaryTime(item, currentSort)
     const previewMedia = resolvePostListPreviewMedia(contentMarkdown, item.coverImage)
     const previewContent = buildPostListPreviewContent({
       contentMarkdown,
@@ -132,8 +158,8 @@ export function mapForumFeedItemsToDisplayItems(
       authorIsVip,
       authorVipLevel: item.authorVipLevel,
       authorNameClassName: getVipNameClass(authorIsVip, item.authorVipLevel, { emphasize: true }),
-      metaPrimary: currentSort === "new" ? item.publishedAt : item.lastRepliedAt,
-      metaPrimaryRaw: currentSort === "new" ? item.publishedAtRaw : item.lastRepliedAtRaw,
+      metaPrimary: primaryTime.label,
+      metaPrimaryRaw: primaryTime.raw,
       metaSecondary: (currentSort === "latest" || currentSort === "new" || currentSort === "hot" || currentSort === "following") && item.latestReplyAuthorName
         ? `最新回复 ${item.latestReplyAuthorName}`
         : null,

--- a/src/lib/forum-feed.ts
+++ b/src/lib/forum-feed.ts
@@ -41,6 +41,8 @@ export interface ForumFeedItem {
   authorVipExpiresAt?: string | null
   publishedAt: string
   publishedAtRaw: string
+  activityAt: string
+  activityAtRaw: string
   lastRepliedAt: string
   lastRepliedAtRaw: string
   latestReplyAuthorName: string | null
@@ -153,6 +155,7 @@ type FeedPost = {
   isFeatured: boolean
   type: LocalPostType | string
   publishedAt: Date | null
+  activityAt?: Date | null
   lastCommentedAt: Date | null
   createdAt: Date
   board: { name: string; slug: string; iconPath: string | null }
@@ -193,6 +196,9 @@ function mapFeedPost(post: FeedPostRecord | PinnedFeedPostRecord, anonymousMaskI
     : (latestReply ? latestReply.user.nickname ?? latestReply.user.username : null)
   const latestReplyAuthorUsername = latestReplyUsesAnonymousIdentity ? null : (latestReply?.user.username ?? null)
   const latestReplyCommentId = latestReply?.id ?? null
+  const publishedAtRaw = feedPost.publishedAt ?? feedPost.createdAt
+  const activityAtRaw = feedPost.activityAt ?? feedPost.lastCommentedAt ?? publishedAtRaw
+  const lastRepliedAtRaw = feedPost.lastCommentedAt ?? publishedAtRaw
 
   return {
     id: feedPost.id,
@@ -210,10 +216,12 @@ function mapFeedPost(post: FeedPostRecord | PinnedFeedPostRecord, anonymousMaskI
     authorStatus: maskedAuthor.authorStatus ?? "ACTIVE",
     authorVipLevel: maskedAuthor.authorVipLevel ?? null,
     authorVipExpiresAt: maskedAuthor.authorIsVip ? (feedPost.author.vipExpiresAt ? new Date(feedPost.author.vipExpiresAt).toISOString() : null) : null,
-    publishedAt: formatRelativeTime(feedPost.publishedAt ?? feedPost.createdAt),
-    publishedAtRaw: (feedPost.publishedAt ?? feedPost.createdAt).toISOString(),
-    lastRepliedAt: formatRelativeTime(feedPost.lastCommentedAt ?? feedPost.publishedAt ?? feedPost.createdAt),
-    lastRepliedAtRaw: (feedPost.lastCommentedAt ?? feedPost.publishedAt ?? feedPost.createdAt).toISOString(),
+    publishedAt: formatRelativeTime(publishedAtRaw),
+    publishedAtRaw: publishedAtRaw.toISOString(),
+    activityAt: formatRelativeTime(activityAtRaw),
+    activityAtRaw: activityAtRaw.toISOString(),
+    lastRepliedAt: formatRelativeTime(lastRepliedAtRaw),
+    lastRepliedAtRaw: lastRepliedAtRaw.toISOString(),
     latestReplyAuthorName,
     latestReplyAuthorUsername,
     latestReplyCommentId,

--- a/test/feed-activity-time-display.test.ts
+++ b/test/feed-activity-time-display.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import test from "node:test"
+
+import type { ForumFeedItem } from "../src/lib/forum-feed"
+import { resolveFeedPrimaryTime } from "../src/lib/forum-feed-display"
+
+const root = process.cwd()
+
+const feedItem = {
+  publishedAt: "published-time",
+  publishedAtRaw: "2026-07-27T01:00:00.000Z",
+  activityAt: "activity-time",
+  activityAtRaw: "2026-07-27T05:00:00.000Z",
+  lastRepliedAt: "reply-time",
+  lastRepliedAtRaw: "2026-07-27T03:00:00.000Z",
+} as ForumFeedItem
+
+test("latest feed displays the same activity timestamp used for ordering", () => {
+  assert.deepEqual(resolveFeedPrimaryTime(feedItem, "latest"), {
+    label: "activity-time",
+    raw: "2026-07-27T05:00:00.000Z",
+  })
+})
+
+test("new feed continues to display the original published timestamp", () => {
+  assert.deepEqual(resolveFeedPrimaryTime(feedItem, "new"), {
+    label: "published-time",
+    raw: "2026-07-27T01:00:00.000Z",
+  })
+})
+
+test("feed mapping carries activityAt separately from reply and publish timestamps", async () => {
+  const source = await readFile(path.join(root, "src/lib/forum-feed.ts"), "utf8")
+
+  assert.match(source, /activityAtRaw = feedPost\.activityAt \?\? feedPost\.lastCommentedAt \?\? publishedAtRaw/)
+  assert.match(source, /activityAt: formatRelativeTime\(activityAtRaw\)/)
+  assert.match(source, /activityAtRaw: activityAtRaw\.toISOString\(\)/)
+})


### PR DESCRIPTION
## 修改内容

- 首页 latest 信息流继续按 `activityAt DESC` 排序
- latest/following/featured 展示与排序一致的活动时间
- new 信息流继续展示发布时间
- 插件处理后的首页列表也同步使用活动时间
- 增加 feed 时间展示边界测试

## 背景

首页“最新”列表按最后活跃时间排序，但原来展示的是发布时间或最后回复时间。旧帖被编辑、追加内容或重新活跃后会排到顶部，但页面仍显示原发布时间，容易让用户误以为排序错误。

## 验证

- pnpm test
- pnpm typecheck
- pnpm lint