### PR TITLE
修复 Node 20 下安全出网请求的 DNS lookup 回调兼容问题

### DIFF
--- a/src/lib/safe-outbound-http.ts
+++ b/src/lib/safe-outbound-http.ts
@@ -172,7 +172,16 @@ export async function safeOutboundFetch(input: string | URL, init: SafeOutboundF
       path: `${target.url.pathname}${target.url.search}`,
       method: init.method ?? "GET",
       headers: headersToNodeHeaders(init.headers),
-      lookup: (_hostname, _options, callback) => callback(null, target.address, target.family),
+      lookup: (_hostname, options, callback) => {
+        // Node 20 may request all addresses when auto family selection is enabled.
+        // Return the pinned address in the shape expected by that callback mode.
+        if (options?.all) {
+          callback(null, [{ address: target.address, family: target.family }])
+          return
+        }
+
+        callback(null, target.address, target.family)
+      },
       servername: target.url.hostname,
     }, (response) => {
       if (settled) {

--- a/test/safe-outbound-http.test.ts
+++ b/test/safe-outbound-http.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import https from "node:https"
 import test from "node:test"
 
 import { isPublicOutboundIp, resolveSafeOutboundTarget, safeOutboundFetch } from "../src/lib/safe-outbound-http"
@@ -20,4 +22,29 @@ test("safe outbound resolver rejects local URL targets before attempting a reque
   await assert.rejects(() => resolveSafeOutboundTarget("http://127.0.0.1:3000"), /禁止访问|内网|保留/)
   await assert.rejects(() => resolveSafeOutboundTarget("http://[::1]:3000"), /禁止访问|内网|保留/)
   await assert.rejects(() => safeOutboundFetch("http://localhost:3000"), /禁止访问|内网|保留/)
+})
+
+test("safe outbound fetch supports Node 20 all-address lookup callbacks", async (t) => {
+  const expectedError = new Error("stop after pinned lookup assertion")
+  let lookupCalled = false
+
+  t.mock.method(https, "request", ((options: https.RequestOptions) => {
+    assert.equal(typeof options.lookup, "function")
+    options.lookup?.("1.1.1.1", { all: true }, (error, addresses) => {
+      assert.equal(error, null)
+      assert.deepEqual(addresses, [{ address: "1.1.1.1", family: 4 }])
+      lookupCalled = true
+    })
+
+    const request = new EventEmitter() as EventEmitter & {
+      destroy: (error?: Error) => void
+      end: () => void
+    }
+    request.destroy = (error) => request.emit("error", error)
+    request.end = () => request.emit("error", expectedError)
+    return request
+  }) as typeof https.request)
+
+  await assert.rejects(() => safeOutboundFetch("https://1.1.1.1"), expectedError)
+  assert.equal(lookupCalled, true)
 })


### PR DESCRIPTION
## 变更

- 兼容 Node 20 在自动地址族选择时传入的 `lookup` `all: true` 回调模式
- 返回已校验并固定的地址数组，继续保持 DNS rebinding 防护
- 增加回归测试，覆盖全地址回调形状

## 背景

`safeOutboundFetch` 原回调始终返回单地址签名；Node 20 请求全地址结果时要求 `LookupAddress[]`，导致部分 RSS 和安全出网请求失败。

## 验证

- `pnpm run prisma:generate`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`：99 项通过