### PR TITLE
支持独立配置登录/注册页展示文字

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -59,7 +59,7 @@ export default async function LoginPage(props: PageProps<"/login">) {
   }
   const page = (
     <AuthShell
-      showcaseName={settings.siteName}
+      showcaseName={settings.authPageShowcaseText || settings.siteName}
       showShowcase={settings.authPageShowcaseEnabled}
       panelTitle="登录账户"
       panelDescription="输入邮箱或用户名和密码，继续你的社区浏览与互动。"

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -65,7 +65,7 @@ export default async function RegisterPage(props: PageProps<"/register">) {
   if (!settings.registrationEnabled) {
     return renderPage(
       <AuthShell
-        showcaseName={settings.siteName}
+        showcaseName={settings.authPageShowcaseText || settings.siteName}
         showShowcase={settings.authPageShowcaseEnabled}
         panelTitle="注册暂未开放"
         panelDescription="稍后再回来看看，或先使用现有账号继续访问社区。"
@@ -98,7 +98,7 @@ export default async function RegisterPage(props: PageProps<"/register">) {
 
   return renderPage(
     <AuthShell
-      showcaseName={settings.siteName}
+      showcaseName={settings.authPageShowcaseText || settings.siteName}
       showShowcase={settings.authPageShowcaseEnabled}
       panelTitle="创建账户"
       panelDescription="花一分钟创建账户，马上开始你的浏览、回复和收藏。"

--- a/src/components/admin/admin-registration-settings-form.tsx
+++ b/src/components/admin/admin-registration-settings-form.tsx
@@ -263,6 +263,13 @@ export function AdminRegistrationSettingsForm({
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
             <AdminBooleanSelectField label="允许新用户注册" checked={draft.registrationEnabled} onChange={(value) => updateDraftField("registrationEnabled", value)} />
             <AdminBooleanSelectField label="显示登录/注册页左侧内容" checked={draft.authPageShowcaseEnabled} onChange={(value) => updateDraftField("authPageShowcaseEnabled", value)} />
+            <TextField
+              label="登录/注册页展示文字"
+              value={draft.authPageShowcaseText}
+              onChange={(value) => updateDraftField("authPageShowcaseText", value)}
+              placeholder="如 Rhex 社区"
+              description="仅用于左侧动画；用空格分隔需要逐词切换的内容，不会改变浏览器标题。"
+            />
             <AdminBooleanSelectField label="显示邀请码输入框" checked={draft.registerInviteCodeEnabled} onChange={(value) => updateDraftField("registerInviteCodeEnabled", value)} />
             <AdminBooleanSelectField label="注册必须邀请码" checked={draft.registrationRequireInviteCode} onChange={(value) => updateDraftField("registrationRequireInviteCode", value)} />
             <AdminBooleanSelectField label="开启积分购买邀请码" checked={draft.inviteCodePurchaseEnabled} onChange={(value) => updateDraftField("inviteCodePurchaseEnabled", value)} />

--- a/src/components/admin/admin-site-settings.shared.tsx
+++ b/src/components/admin/admin-site-settings.shared.tsx
@@ -59,6 +59,7 @@ export interface AdminBasicSettingsInitialSettings {
   registerInitialPoints: number
   registrationEnabled: boolean
   authPageShowcaseEnabled: boolean
+  authPageShowcaseText: string
   registrationRequireInviteCode: boolean
   registerInviteCodeEnabled: boolean
   registerInviteCodeHelpEnabled: boolean
@@ -247,6 +248,7 @@ export interface AdminBasicSettingsDraft {
   registerInitialPoints: string
   registrationEnabled: boolean
   authPageShowcaseEnabled: boolean
+  authPageShowcaseText: string
   registrationRequireInviteCode: boolean
   registerInviteCodeEnabled: boolean
   registerInviteCodeHelpEnabled: boolean
@@ -508,6 +510,7 @@ export function createAdminBasicSettingsDraft(initialSettings: AdminBasicSetting
     registerInitialPoints: coerceNumberString(initialSettings.registerInitialPoints, 0),
     registrationEnabled: coerceBoolean(initialSettings.registrationEnabled, true),
     authPageShowcaseEnabled: coerceBoolean(initialSettings.authPageShowcaseEnabled, true),
+    authPageShowcaseText: coerceString(initialSettings.authPageShowcaseText),
     registrationRequireInviteCode: coerceBoolean(initialSettings.registrationRequireInviteCode, false),
     registerInviteCodeEnabled: coerceBoolean(initialSettings.registerInviteCodeEnabled, true),
     registerInviteCodeHelpEnabled: coerceBoolean(initialSettings.registerInviteCodeHelpEnabled, false),
@@ -689,6 +692,7 @@ export function buildAdminBasicSettingsPayload(draft: AdminBasicSettingsDraft, m
       registerInitialPoints: Number(draft.registerInitialPoints),
       registrationEnabled: draft.registrationEnabled,
       authPageShowcaseEnabled: draft.authPageShowcaseEnabled,
+      authPageShowcaseText: draft.authPageShowcaseText,
       registrationRequireInviteCode: draft.registrationRequireInviteCode,
       registerInviteCodeEnabled: draft.registerInviteCodeEnabled,
       registerInviteCodeHelpEnabled: draft.registerInviteCodeHelpEnabled,

--- a/src/lib/admin-site-settings-registration.ts
+++ b/src/lib/admin-site-settings-registration.ts
@@ -16,6 +16,7 @@ import {
   mergeSmsProviderSettings,
   mergeUsernameSensitiveWordSettings,
   resolveRegisterInviteCodeHelpSettings,
+  resolveAuthPageShowcaseSettings,
   resolveRegisterEmailWhitelistSettings,
   resolveRegistrationEmailTemplateSettings,
   resolveRegisterNicknameLengthSettings,
@@ -76,6 +77,11 @@ export async function updateRegistrationSiteSettingsSection(existing: SiteSettin
   const existingRegisterInviteCodeHelpSettings = resolveRegisterInviteCodeHelpSettings({
     appStateJson: existing.appStateJson,
   })
+  const existingAuthPageShowcaseSettings = resolveAuthPageShowcaseSettings({
+    appStateJson: existing.appStateJson,
+    enabledFallback: true,
+    textFallback: "",
+  })
   const existingRegisterEmailWhitelistSettings = resolveRegisterEmailWhitelistSettings({
     appStateJson: existing.appStateJson,
   })
@@ -92,6 +98,9 @@ export async function updateRegistrationSiteSettingsSection(existing: SiteSettin
   })
   const registrationEnabled = Boolean(body.registrationEnabled)
   const authPageShowcaseEnabled = "authPageShowcaseEnabled" in body ? Boolean(body.authPageShowcaseEnabled) : true
+  const authPageShowcaseText = "authPageShowcaseText" in body
+    ? (readOptionalStringField(body, "authPageShowcaseText") ?? "")
+    : existingAuthPageShowcaseSettings.text
   const registrationRequireInviteCode = Boolean(body.registrationRequireInviteCode)
   const registerInviteCodeEnabled = Boolean(body.registerInviteCodeEnabled)
   const registerInviteCodeHelpEnabled = registerInviteCodeEnabled && Boolean(body.registerInviteCodeHelpEnabled)
@@ -322,6 +331,7 @@ export async function updateRegistrationSiteSettingsSection(existing: SiteSettin
   })
   const appStateWithAuthPageShowcase = mergeAuthPageShowcaseSettings(appStateWithAuthProviders, {
     enabled: authPageShowcaseEnabled,
+    text: authPageShowcaseText,
   })
   const appStateWithRegisterNicknameLengths = mergeRegisterNicknameLengthSettings(appStateWithAuthPageShowcase, {
     minLength: registerNicknameMinLength,

--- a/src/lib/site-settings-app-state.registration.ts
+++ b/src/lib/site-settings-app-state.registration.ts
@@ -677,6 +677,7 @@ export function mergeSmsProviderSettings(
 export function resolveAuthPageShowcaseSettings(options: {
   appStateJson?: string | null
   enabledFallback?: boolean
+  textFallback?: string
 } = {}): AuthPageShowcaseSettings {
   const siteSettingsState = readSiteSettingsState(options.appStateJson)
   const authPageShowcase = isRecord(siteSettingsState.authPageShowcase)
@@ -688,6 +689,10 @@ export function resolveAuthPageShowcaseSettings(options: {
       typeof authPageShowcase.enabled === "boolean"
         ? authPageShowcase.enabled
         : options.enabledFallback ?? true,
+    text:
+      typeof authPageShowcase.text === "string"
+        ? authPageShowcase.text.trim().slice(0, 120)
+        : (options.textFallback ?? "").trim().slice(0, 120),
   }
 }
 
@@ -701,6 +706,7 @@ export function mergeAuthPageShowcaseSettings(
     ...siteSettingsState,
     authPageShowcase: {
       enabled: Boolean(input.enabled),
+      text: input.text.trim().slice(0, 120),
     },
   })
 }

--- a/src/lib/site-settings-app-state.types.ts
+++ b/src/lib/site-settings-app-state.types.ts
@@ -361,6 +361,7 @@ export interface SmsProviderSettings {
 
 export interface AuthPageShowcaseSettings {
   enabled: boolean
+  text: string
 }
 
 export type VipLevelIconSettings = VipLevelIcons

--- a/src/lib/site-settings.registration.ts
+++ b/src/lib/site-settings.registration.ts
@@ -7,6 +7,7 @@ import type { SmsBuiltinProvider } from "@/lib/site-settings-app-state.types"
 export interface SiteSettingsRegistrationData extends UsernameSensitiveWordSettings {
   registrationEnabled: boolean
   authPageShowcaseEnabled: boolean
+  authPageShowcaseText: string
   registrationRequireInviteCode: boolean
   registerInviteCodeEnabled: boolean
   registerInviteCodeHelpEnabled: boolean

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -404,6 +404,7 @@ function mapSiteSettings(record: SiteSettingsRecordData, tippingGifts: SiteTippi
   const authPageShowcaseSettings = resolveAuthPageShowcaseSettings({
     appStateJson: record.appStateJson,
     enabledFallback: true,
+    textFallback: "",
   })
   const smsProviderSettings = resolveSmsProviderSettings({
     appStateJson: record.appStateJson,
@@ -530,6 +531,7 @@ function mapSiteSettings(record: SiteSettingsRecordData, tippingGifts: SiteTippi
     registerInitialPoints: registrationRewardSettings.initialPoints,
     registrationEnabled: record.registrationEnabled,
     authPageShowcaseEnabled: authPageShowcaseSettings.enabled,
+    authPageShowcaseText: authPageShowcaseSettings.text,
     registrationRequireInviteCode: record.registrationRequireInviteCode,
     registerInviteCodeEnabled: record.registerInviteCodeEnabled,
     registerInviteCodeHelpEnabled: registerInviteCodeHelpSettings.enabled,

--- a/test/auth-page-showcase-settings.test.ts
+++ b/test/auth-page-showcase-settings.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  mergeAuthPageShowcaseSettings,
+  resolveAuthPageShowcaseSettings,
+} from "../src/lib/site-settings-app-state.registration"
+
+test("auth page showcase settings persist independent display text", () => {
+  const appStateJson = mergeAuthPageShowcaseSettings(null, {
+    enabled: false,
+    text: "  Community Focus  ",
+  })
+
+  assert.deepEqual(resolveAuthPageShowcaseSettings({ appStateJson }), {
+    enabled: false,
+    text: "Community Focus",
+  })
+})
+
+test("auth page showcase text supports legacy state and remains bounded", () => {
+  const legacyState = JSON.stringify({ authPageShowcase: { enabled: true } })
+  assert.deepEqual(resolveAuthPageShowcaseSettings({
+    appStateJson: legacyState,
+    textFallback: "Site Name",
+  }), {
+    enabled: true,
+    text: "Site Name",
+  })
+
+  const longText = "x".repeat(160)
+  const appStateJson = mergeAuthPageShowcaseSettings(null, {
+    enabled: true,
+    text: longText,
+  })
+  assert.equal(resolveAuthPageShowcaseSettings({ appStateJson }).text, "x".repeat(120))
+})


### PR DESCRIPTION
## 变更

- 在注册设置中增加独立的登录/注册页展示文字
- 登录页和注册页优先使用该文字，未配置时回退到站点名称
- 配置保存到 app state，兼容旧数据，并限制为 120 个字符
- 增加持久化、旧数据回退和长度限制测试

## 用途

站点标题通常包含 SEO 描述，不适合直接用于登录/注册页左侧逐词动画。此配置让展示文案与浏览器标题相互独立。

## 验证

- `pnpm run prisma:generate`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`：100 项通过