### PR TITLE
fix(write): keep enhancements panel below header

### DIFF
--- a/src/components/post/create-post-form-sections/post-enhancements-section.tsx
+++ b/src/components/post/create-post-form-sections/post-enhancements-section.tsx
@@ -32,6 +32,10 @@ import {
 } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
 import { formatCompactPointValue } from "@/lib/formatters"
+import {
+  clampFloatingPanelPosition,
+  type FloatingPanelPosition,
+} from "@/lib/floating-panel-position"
 import { getPostRewardPoolModeLabel } from "@/lib/post-reward-pool-config"
 
 const DESKTOP_PANEL_STORAGE_KEY = "post-enhancements-panel-position"
@@ -40,9 +44,30 @@ const DESKTOP_PANEL_WIDTH = 202
 const DESKTOP_PANEL_MARGIN = 12
 const DESKTOP_PANEL_DEFAULT_TOP = 112
 
-interface DesktopPanelPosition {
-  left: number
-  top: number
+type DesktopPanelPosition = FloatingPanelPosition
+
+function getDesktopPanelMinimumTop() {
+  if (typeof window === "undefined") {
+    return DESKTOP_PANEL_MARGIN
+  }
+
+  const header = Array.from(document.querySelectorAll<HTMLElement>("header")).find((element) => {
+    const style = window.getComputedStyle(element)
+    const rect = element.getBoundingClientRect()
+    return (style.position === "fixed" || style.position === "sticky")
+      && rect.top <= DESKTOP_PANEL_MARGIN
+      && rect.bottom > 0
+      && rect.width >= window.innerWidth / 2
+  })
+
+  if (!header) {
+    return DESKTOP_PANEL_MARGIN
+  }
+
+  return Math.max(
+    DESKTOP_PANEL_MARGIN,
+    Math.ceil(header.getBoundingClientRect().bottom) + DESKTOP_PANEL_MARGIN,
+  )
 }
 
 function DesktopActionCard({
@@ -408,13 +433,14 @@ export function PostEnhancementsSection({
 
     const panelWidth = desktopPanelRef.current?.offsetWidth ?? DESKTOP_PANEL_WIDTH
     const panelHeight = desktopPanelRef.current?.offsetHeight ?? 420
-    const maxLeft = Math.max(DESKTOP_PANEL_MARGIN, window.innerWidth - panelWidth - DESKTOP_PANEL_MARGIN)
-    const maxTop = Math.max(DESKTOP_PANEL_MARGIN, window.innerHeight - panelHeight - DESKTOP_PANEL_MARGIN)
-
-    return {
-      left: Math.min(Math.max(DESKTOP_PANEL_MARGIN, position.left), maxLeft),
-      top: Math.min(Math.max(DESKTOP_PANEL_MARGIN, position.top), maxTop),
-    }
+    return clampFloatingPanelPosition(position, {
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      panelWidth,
+      panelHeight,
+      margin: DESKTOP_PANEL_MARGIN,
+      minimumTop: getDesktopPanelMinimumTop(),
+    })
   }
   const desktopPanelPosition = desktopPanelPositionOverride
     ?? (persistedDesktopPanelPreferences.position

--- a/src/lib/floating-panel-position.ts
+++ b/src/lib/floating-panel-position.ts
@@ -1,0 +1,34 @@
+export interface FloatingPanelPosition {
+  left: number
+  top: number
+}
+
+interface FloatingPanelBounds {
+  viewportWidth: number
+  viewportHeight: number
+  panelWidth: number
+  panelHeight: number
+  margin: number
+  minimumTop?: number
+}
+
+export function clampFloatingPanelPosition(
+  position: FloatingPanelPosition,
+  bounds: FloatingPanelBounds,
+): FloatingPanelPosition {
+  const minimumLeft = bounds.margin
+  const minimumTop = Math.max(bounds.margin, bounds.minimumTop ?? bounds.margin)
+  const maximumLeft = Math.max(
+    minimumLeft,
+    bounds.viewportWidth - bounds.panelWidth - bounds.margin,
+  )
+  const maximumTop = Math.max(
+    minimumTop,
+    bounds.viewportHeight - bounds.panelHeight - bounds.margin,
+  )
+
+  return {
+    left: Math.min(Math.max(minimumLeft, position.left), maximumLeft),
+    top: Math.min(Math.max(minimumTop, position.top), maximumTop),
+  }
+}

--- a/test/floating-panel-position.test.ts
+++ b/test/floating-panel-position.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { clampFloatingPanelPosition } from "../src/lib/floating-panel-position"
+
+const bounds = {
+  viewportWidth: 1440,
+  viewportHeight: 900,
+  panelWidth: 202,
+  panelHeight: 554,
+  margin: 12,
+  minimumTop: 68,
+}
+
+test("floating panels stay below fixed header chrome", () => {
+  assert.deepEqual(
+    clampFloatingPanelPosition({ left: 600, top: 12 }, bounds),
+    { left: 600, top: 68 },
+  )
+})
+
+test("floating panels remain inside the right and bottom viewport edges", () => {
+  assert.deepEqual(
+    clampFloatingPanelPosition({ left: 2000, top: 2000 }, bounds),
+    { left: 1226, top: 334 },
+  )
+})
+
+test("the header boundary wins when the panel is taller than the available viewport", () => {
+  assert.deepEqual(
+    clampFloatingPanelPosition(
+      { left: -100, top: -100 },
+      { ...bounds, viewportHeight: 500 },
+    ),
+    { left: 12, top: 68 },
+  )
+})


### PR DESCRIPTION
## Summary

- Keep the desktop post enhancements panel below the visible fixed/sticky header.
- Clamp restored, dragged, reset, and resized positions using the measured header boundary.
- Extract the viewport clamping logic into a small testable helper.

## Why

The panel could be dragged to `top: 12px` while the site header occupied the top 56px with a higher z-index. The drag handle then sat behind the header and could no longer receive pointer events. Existing invalid positions in local storage had the same problem after reload.

## Validation

- `pnpm test`: 112 passed, 0 failed.
- Production typecheck, lint, and build passed in CI.
- Browser regression on the deployed image: stored-position recovery, top/left/right/bottom bounds, persistence, collapse/expand, reset, desktop resize, mobile layout, HTTP/request/page checks all passed.
- The deployed image was verified on the production site at `malaixiya.my`.
