### PR TITLE
fix: improve Docker installs, compact links, and S3 uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV NEXT_DEPLOYMENT_ID=${NEXT_DEPLOYMENT_ID}
 
 RUN mkdir -p addons
 
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY prisma ./prisma
 
 RUN if [ -n "${PNPM_REGISTRY}" ]; then pnpm config set registry "${PNPM_REGISTRY}"; fi \
@@ -53,7 +53,7 @@ RUN pnpm run prisma:generate \
 
 FROM base AS production-dependencies
 
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 # setup:prod and worker execute these binaries directly at runtime.
 RUN pnpm install --prod --frozen-lockfile \

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -564,7 +564,6 @@ export default async function PostPage(props: PageProps<"/posts/[slug]">) {
               <div className="space-y-0">
                   <PostBodyCopyMenu
                     post={{ id: displayPost.id, slug: displayPost.slug }}
-                    postLinkDisplayMode={settings.postLinkDisplayMode}
                     canReport={Boolean(currentUser && currentUser.id !== displayPostWithAiIndicator.authorId)}
                     reportTargetId={displayPostWithAiIndicator.id}
                     reportLabel={displayPostWithAiIndicator.title}

--- a/src/components/comment/comment-thread-shared.tsx
+++ b/src/components/comment/comment-thread-shared.tsx
@@ -306,7 +306,7 @@ export function CommentThreadReplyBox({ postId, commentsVisibleToAuthorOnly, ano
         className={cn(
           "min-w-0 max-w-full rounded-xl bg-card",
           isPinnedLayout && "overflow-hidden rounded-xl border border-border/80 bg-card",
-          isFloatingPinnedLayout && "fixed inset-x-3 bottom-3 z-50 max-h-[calc(100dvh-1.5rem)] max-w-[calc(100vw-1.5rem)] overflow-x-hidden overflow-y-auto overscroll-contain bg-card/95 shadow-[0_-18px_48px_rgba(15,23,42,0.16)] [scrollbar-width:none] backdrop-blur-xl [-ms-overflow-style:none] sm:inset-x-auto sm:[left:var(--comment-reply-box-left)] sm:[width:min(var(--comment-reply-box-width),calc(100vw-1.5rem))] [&::-webkit-scrollbar]:hidden",
+          isFloatingPinnedLayout && "fixed inset-x-3 bottom-3 z-50 max-h-[calc(100dvh-1.5rem)] max-w-[calc(100vw-1.5rem)] overflow-x-hidden overflow-y-auto bg-card/95 shadow-[0_-18px_48px_rgba(15,23,42,0.16)] [scrollbar-width:none] backdrop-blur-xl [-ms-overflow-style:none] sm:inset-x-auto sm:[left:var(--comment-reply-box-left)] sm:[width:min(var(--comment-reply-box-width),calc(100vw-1.5rem))] [&::-webkit-scrollbar]:hidden",
         )}
         style={floatingPinnedStyle}
       >

--- a/src/components/comment/comment-thread.tsx
+++ b/src/components/comment/comment-thread.tsx
@@ -464,6 +464,30 @@ function CommentThreadContent({ threadId, comments, flatComments = [], postId, p
       setHighlightedCommentId((current) => current === highlightedCommentId ? null : current)
     }, COMMENT_HIGHLIGHT_CLEAR_DELAY_MS)
 
+    const cancelAnchorScrollOnUserIntent = (event: Event) => {
+      if (event.type === "keydown") {
+        const key = (event as KeyboardEvent).key
+        if (!(key === "ArrowUp" || key === "ArrowDown" || key === "PageUp" || key === "PageDown" || key === "Home" || key === "End" || key === " ")) {
+          return
+        }
+      }
+
+      cancelled = true
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      if (retryTimeoutId !== null) {
+        window.clearTimeout(retryTimeoutId)
+        retryTimeoutId = null
+      }
+      setHighlightedCommentId((current) => current === highlightedCommentId ? null : current)
+    }
+
+    window.addEventListener("wheel", cancelAnchorScrollOnUserIntent, { passive: true })
+    window.addEventListener("touchstart", cancelAnchorScrollOnUserIntent, { passive: true })
+    window.addEventListener("keydown", cancelAnchorScrollOnUserIntent)
+
     return () => {
       cancelled = true
       if (rafId !== null) {
@@ -473,6 +497,9 @@ function CommentThreadContent({ threadId, comments, flatComments = [], postId, p
         window.clearTimeout(retryTimeoutId)
       }
       window.clearTimeout(timeoutId)
+      window.removeEventListener("wheel", cancelAnchorScrollOnUserIntent)
+      window.removeEventListener("touchstart", cancelAnchorScrollOnUserIntent)
+      window.removeEventListener("keydown", cancelAnchorScrollOnUserIntent)
     }
   }, [clearCommentHighlightSearchParam, ensureHighlightedCommentVisible, highlightedCommentId])
 

--- a/src/components/post/post-body-copy-menu.tsx
+++ b/src/components/post/post-body-copy-menu.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button"
 import { toast } from "@/components/ui/toast"
 import { copyTextToClipboard } from "@/lib/clipboard"
 import { formatCompactNumber, formatNumber } from "@/lib/formatters"
-import { getPostPath } from "@/lib/post-links"
+import { getPostShortPath } from "@/lib/post-links"
 import { cn } from "@/lib/utils"
 
 interface PostBodyCopyMenuProps {
@@ -28,7 +28,7 @@ interface PostBodyCopyMenuProps {
 export function PostBodyCopyMenu({ post, canReport = false, reportTargetId, reportLabel = "当前帖子", initialFollowed, viewCount, children }: PostBodyCopyMenuProps) {
   const [isHovered, setIsHovered] = useState(false)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const copyPath = getPostPath(post, { mode: "ID" })
+  const copyPath = getPostShortPath(post)
   const copyLink = (() => {
     if (typeof window === "undefined") {
       return copyPath

--- a/src/components/post/post-body-copy-menu.tsx
+++ b/src/components/post/post-body-copy-menu.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState, type PointerEvent, type ReactNode } from "react"
+import { useState, type PointerEvent, type ReactNode } from "react"
 import { Copy, Ellipsis, Eye, Flag } from "lucide-react"
 
 import { FollowToggleButton } from "@/components/follow-toggle-button"
@@ -10,7 +10,6 @@ import { toast } from "@/components/ui/toast"
 import { copyTextToClipboard } from "@/lib/clipboard"
 import { formatCompactNumber, formatNumber } from "@/lib/formatters"
 import { getPostPath } from "@/lib/post-links"
-import type { PostLinkDisplayMode } from "@/lib/site-settings"
 import { cn } from "@/lib/utils"
 
 interface PostBodyCopyMenuProps {
@@ -18,7 +17,6 @@ interface PostBodyCopyMenuProps {
     id: string
     slug: string
   }
-  postLinkDisplayMode?: PostLinkDisplayMode
   canReport?: boolean
   reportTargetId?: string
   reportLabel?: string
@@ -27,20 +25,17 @@ interface PostBodyCopyMenuProps {
   children: ReactNode
 }
 
-export function PostBodyCopyMenu({ post, postLinkDisplayMode = "SLUG", canReport = false, reportTargetId, reportLabel = "当前帖子", initialFollowed, viewCount, children }: PostBodyCopyMenuProps) {
+export function PostBodyCopyMenu({ post, canReport = false, reportTargetId, reportLabel = "当前帖子", initialFollowed, viewCount, children }: PostBodyCopyMenuProps) {
   const [isHovered, setIsHovered] = useState(false)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const copyPath = useMemo(
-    () => getPostPath(post, { mode: postLinkDisplayMode }),
-    [post, postLinkDisplayMode],
-  )
-  const copyLink = useMemo(() => {
+  const copyPath = getPostPath(post, { mode: "ID" })
+  const copyLink = (() => {
     if (typeof window === "undefined") {
       return copyPath
     }
 
     return `${window.location.origin}${copyPath}`
-  }, [copyPath])
+  })()
 
   async function handleCopyLink() {
     if (await copyTextToClipboard(copyLink)) {

--- a/src/lib/post-links.ts
+++ b/src/lib/post-links.ts
@@ -29,6 +29,13 @@ export function getPostPath(post: { id: string; slug: string }, options?: PostLi
   return `/posts/${encodeURIComponent(getPostRouteSegment(post, mode))}`
 }
 
+export function getPostShortPath(post: { slug: string }) {
+  const slug = post.slug.trim()
+  const shortSegment = slug.split("-").at(-1)?.trim() || slug
+
+  return `/posts/${encodeURIComponent(shortSegment)}`
+}
+
 
 
 export function getPostCommentPath(

--- a/src/lib/s3-upload-body.ts
+++ b/src/lib/s3-upload-body.ts
@@ -1,0 +1,8 @@
+/**
+ * Some S3-compatible gateways reject streamed PutObject bodies with 411 even
+ * when the SDK receives ContentLength. Materialize only the remote-upload
+ * body so the request has a concrete, non-chunked payload.
+ */
+export async function resolveS3UploadBody(file: File, preparedBuffer: Buffer | null) {
+  return preparedBuffer ?? Buffer.from(await file.arrayBuffer())
+}

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/addon-upload-providers"
 import type { AddonUploadActor } from "@/addons-host/upload-types"
 import { resolveWatermarkLogoBuffer } from "@/lib/watermark-logo.server"
+import { resolveS3UploadBody } from "@/lib/s3-upload-body"
 
 export interface SavedUploadFile {
   fileName: string
@@ -441,10 +442,12 @@ async function saveToOss(
   const objectKey = resolveS3ObjectKey(folder, fileName)
   const client = createS3Client(settings)
 
+  const uploadBody = await resolveS3UploadBody(file, preparedFile.buffer)
+
   await client.send(new PutObjectCommand({
     Bucket: settings.uploadOssBucket ?? undefined,
     Key: objectKey,
-    Body: preparedFile.buffer ?? createNodeReadableFromFile(file),
+    Body: uploadBody,
     ContentType: preparedFile.detectedMime,
     ContentLength: preparedFile.fileSize,
     CacheControl: "public, max-age=31536000, immutable",

--- a/test/comment-anchor-scroll-interrupt.test.ts
+++ b/test/comment-anchor-scroll-interrupt.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+test("comment anchor scrolling stops when the user starts scrolling", async () => {
+  const source = await readFile("src/components/comment/comment-thread.tsx", "utf8")
+
+  assert.match(source, /addEventListener\("wheel", cancelAnchorScrollOnUserIntent, \{ passive: true \}\)/)
+  assert.match(source, /addEventListener\("touchstart", cancelAnchorScrollOnUserIntent, \{ passive: true \}\)/)
+  assert.match(source, /clearTimeout\(retryTimeoutId\)/)
+  assert.match(source, /setHighlightedCommentId\(\(current\) => current === highlightedCommentId \? null : current\)/)
+})

--- a/test/comment-reply-scroll-boundary.test.ts
+++ b/test/comment-reply-scroll-boundary.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+test("floating reply box does not contain page overscroll", async () => {
+  const source = await readFile("src/components/comment/comment-thread-shared.tsx", "utf8")
+
+  assert.doesNotMatch(source, /isFloatingPinnedLayout[^\n]*overscroll-contain/)
+})

--- a/test/post-links.test.ts
+++ b/test/post-links.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { getPostShortPath } from "../src/lib/post-links"
+
+test("short post links use the existing timestamp suffix", () => {
+  assert.equal(
+    getPostShortPath({ slug: "points-exchange-rm1-1785330644517" }),
+    "/posts/1785330644517",
+  )
+})
+
+test("short post links preserve sequential numeric slugs", () => {
+  assert.equal(getPostShortPath({ slug: "1785330644517" }), "/posts/1785330644517")
+})
+
+test("short post links fall back to the complete slug when no suffix exists", () => {
+  assert.equal(getPostShortPath({ slug: "welcome" }), "/posts/welcome")
+})

--- a/test/upload-s3-compatibility.test.ts
+++ b/test/upload-s3-compatibility.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { resolveS3UploadBody } from "../src/lib/s3-upload-body"
+
+test("S3 uploads materialize streamed files into a concrete body", async () => {
+  const file = {
+    arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+  } as Pick<File, "arrayBuffer">
+
+  const body = await resolveS3UploadBody(file as File, null)
+
+  assert.ok(Buffer.isBuffer(body))
+  assert.deepEqual([...body], [1, 2, 3, 4])
+})
+
+test("S3 uploads reuse an already prepared image buffer", async () => {
+  const preparedBuffer = Buffer.from("prepared")
+  const file = {
+    arrayBuffer: async () => {
+      throw new Error("file should not be read when a prepared buffer exists")
+    },
+  } as Pick<File, "arrayBuffer">
+
+  const body = await resolveS3UploadBody(file as File, preparedBuffer)
+
+  assert.strictEqual(body, preparedBuffer)
+})


### PR DESCRIPTION
## Summary

- Copy the existing post slug suffix for compact links such as `/posts/1785330644517`.
- Preserve full title slugs, existing numeric links, and CUID route compatibility.
- Allow the page to continue scrolling when the floating reply box is visible.
- Copy `pnpm-workspace.yaml` in Docker dependency stages so workspace installs remain reproducible.
- Materialize S3-compatible upload bodies to avoid 411 responses from gateways such as OpenList.

## Validation

- Type check passed.
- Lint passed.
- Production build passed.
- All 118 tests passed, including short-link and floating-reply scroll regression coverage.