### PR TITLE
fix: refresh cached surfaces after mutations

### DIFF
--- a/src/components/badge-center.tsx
+++ b/src/components/badge-center.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { useMemo, useState, useTransition } from "react"
 
 import { LevelIcon } from "@/components/level-icon"
@@ -58,6 +59,7 @@ interface BadgeCenterProps {
 const MAX_DISPLAYED_BADGES = 3
 
 export function BadgeCenter({ badges, isLoggedIn, pointName = "积分" }: BadgeCenterProps) {
+  const router = useRouter()
   const [items, setItems] = useState(badges)
   const [activeCategory, setActiveCategory] = useState<string>("全部")
   const [feedback, setFeedback] = useState("")
@@ -104,6 +106,9 @@ export function BadgeCenter({ badges, isLoggedIn, pointName = "积分" }: BadgeC
             canDisplay: true,
           },
         } : item)))
+        // A fetch does not invalidate the browser App Router cache. Refresh
+        // after the local update so related surfaces see the same write.
+        router.refresh()
       }
     })
   }
@@ -159,6 +164,7 @@ export function BadgeCenter({ badges, isLoggedIn, pointName = "积分" }: BadgeC
           },
         }
       }))
+      router.refresh()
     })
   }
 

--- a/src/components/comment/comment-like-button.tsx
+++ b/src/components/comment/comment-like-button.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
 import { ThumbsUp } from "lucide-react"
 
 import { toast } from "@/components/ui/toast"
@@ -12,6 +13,7 @@ interface CommentLikeButtonProps {
 }
 
 export function CommentLikeButton({ commentId, initialCount, initialLiked = false }: CommentLikeButtonProps) {
+  const router = useRouter()
   const [count, setCount] = useState(initialCount)
   const [liked, setLiked] = useState(initialLiked)
   const [isPending, startTransition] = useTransition()
@@ -39,6 +41,7 @@ export function CommentLikeButton({ commentId, initialCount, initialLiked = fals
             const nextLiked = Boolean(result.data?.liked)
             setLiked(nextLiked)
             setCount((current) => current + (nextLiked ? 1 : -1))
+            router.refresh()
             toast.success(result.message ?? (nextLiked ? "点赞成功" : "已取消点赞"), nextLiked ? "点赞成功" : "取消点赞成功")
           })
         }}

--- a/src/components/follow-toggle-button.tsx
+++ b/src/components/follow-toggle-button.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Heart } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useState, useTransition, type ComponentProps } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -38,6 +39,7 @@ function FollowToggleButtonContent({
   variant,
   size,
 }: FollowToggleButtonProps) {
+  const router = useRouter()
   const [followed, setFollowed] = useState(initialFollowed)
   const [isPending, startTransition] = useTransition()
   const label = followed ? activeLabel : inactiveLabel
@@ -78,6 +80,9 @@ function FollowToggleButtonContent({
           const changed = Boolean(result.data?.changed)
           setFollowed(resolvedFollowed)
           onFollowStateChange?.({ followed: resolvedFollowed, changed })
+          if (changed) {
+            router.refresh()
+          }
           toast.success(result.message ?? (resolvedFollowed ? "关注成功" : "已取消关注"))
         })
       }}

--- a/src/components/post/inline-tip-button.tsx
+++ b/src/components/post/inline-tip-button.tsx
@@ -1,6 +1,7 @@
 ﻿"use client"
 
 import { Gift } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useMemo, useState, useTransition } from "react"
 
 import { LevelIcon } from "@/components/level-icon"
@@ -79,6 +80,7 @@ export function InlineTipButton({
   totalPoints = 0,
   className,
 }: InlineTipButtonProps) {
+  const router = useRouter()
   const normalizedAmounts = useMemo(() => allowedAmounts.filter((amount) => Number.isInteger(amount) && amount > 0), [allowedAmounts])
   const normalizedGifts = useMemo(() => gifts.filter((gift) => gift.id && gift.price > 0), [gifts])
   const [open, setOpen] = useState(false)
@@ -162,6 +164,7 @@ export function InlineTipButton({
         if (result.data) {
           syncSummary(result.data)
         }
+        router.refresh()
 
         const successMessage = result.message ?? (targetGift ? `已送出 ${targetGift.name}` : `已成功打赏 ${formatCompactPointValue(targetAmount)} ${pointName}`)
         setMessage(successMessage)

--- a/src/components/post/post-engagement-bar.tsx
+++ b/src/components/post/post-engagement-bar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Bookmark, Flag, ThumbsUp } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useState, useTransition } from "react"
 
 import { PostAuthorInlineCard } from "@/components/post/post-author-inline-card"
@@ -63,6 +64,7 @@ const engagementToggleClassName = "h-auto min-w-0 rounded-full p-0 text-muted-fo
 
 export function PostEngagementBar({ postId, postSlug, author, likeCount, favoriteCount = 0, initialLiked = false, initialFavored = false, canReport = false, reportLabel = "当前帖子", redPacket, tipping }: PostEngagementBarProps) {
 
+  const router = useRouter()
   const [likes, setLikes] = useState(likeCount)
   const [favorites, setFavorites] = useState(favoriteCount)
   const [liked, setLiked] = useState(initialLiked)
@@ -93,6 +95,7 @@ export function PostEngagementBar({ postId, postSlug, author, likeCount, favorit
           const nextLiked = Boolean(result.data?.liked)
           setLiked(nextLiked)
           setLikes((current) => current + (nextLiked ? 1 : -1))
+          router.refresh()
           toast.success(
             result.message ?? (nextLiked ? "点赞成功" : "已取消点赞"),
             nextLiked ? "点赞成功" : "取消点赞成功",
@@ -103,6 +106,7 @@ export function PostEngagementBar({ postId, postSlug, author, likeCount, favorit
         const nextFavored = Boolean(result.data?.favored)
         setFavored(nextFavored)
         setFavorites((current) => current + (nextFavored ? 1 : -1))
+        router.refresh()
         toast.success(
           result.message ?? (nextFavored ? "收藏成功" : "已取消收藏"),
           nextFavored ? "收藏成功" : "取消收藏成功",

--- a/src/components/post/post-tip-panel.tsx
+++ b/src/components/post/post-tip-panel.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown, ChevronUp, Gift, Zap } from "lucide-react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, useTransition } from "react"
 import { createPortal } from "react-dom"
 
@@ -136,6 +137,7 @@ export function PostTipPanel({
   totalPoints,
   topSupporters,
 }: PostTipPanelProps) {
+  const router = useRouter()
   const animationTimersRef = useRef<number[]>([])
   const seededRecentEventIdsRef = useRef(new Set<string>())
   const laneCursorRef = useRef(0)
@@ -386,6 +388,7 @@ export function PostTipPanel({
         if (result.data) {
           syncSummary(result.data)
         }
+        router.refresh()
 
         const successMessage = result.message ?? (targetGift ? `已送出 ${targetGift.name}` : `已成功打赏 ${formatCompactPointValue(targetAmount)} ${pointName}`)
         setMessage(successMessage)

--- a/src/components/user/user-block-toggle-button.tsx
+++ b/src/components/user/user-block-toggle-button.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { UserX } from "lucide-react"
 
 import { showConfirm } from "@/components/ui/alert-dialog"
@@ -30,6 +31,7 @@ export function UserBlockToggleButton({
   reloadOnChange = false,
   onBlockStateChange,
 }: UserBlockToggleButtonProps) {
+  const router = useRouter()
   const [blockedState, setBlockedState] = useState(() => ({
     targetUserId,
     initialBlocked,
@@ -87,11 +89,11 @@ export function UserBlockToggleButton({
         value: resolvedBlocked,
       })
       onBlockStateChange?.({ blocked: resolvedBlocked, changed })
+      if (changed || reloadOnChange) {
+        router.refresh()
+      }
       toast.success(result.message ?? (resolvedBlocked ? "已拉黑该用户" : "已取消拉黑"))
 
-      if (reloadOnChange && changed) {
-        window.location.reload()
-      }
     } catch {
       toast.error("拉黑操作失败")
     } finally {

--- a/src/lib/badge-cache-revalidation.ts
+++ b/src/lib/badge-cache-revalidation.ts
@@ -32,7 +32,7 @@ function safeRevalidatePath(path: string, type?: "page" | "layout") {
       return
     }
 
-    throw error
+    console.warn("[cache] path revalidation skipped", error)
   }
 }
 
@@ -44,7 +44,7 @@ function safeExpireTag(tag: string) {
       return
     }
 
-    throw error
+    console.warn("[cache] tag revalidation skipped", error)
   }
 }
 

--- a/src/lib/content-list-cache.ts
+++ b/src/lib/content-list-cache.ts
@@ -22,7 +22,7 @@ function revalidateContentListTag(tag: string, profile: ContentListRevalidatePro
       return
     }
 
-    throw error
+    console.warn("[cache] content list revalidation skipped", error)
   }
 }
 

--- a/src/lib/post-detail-cache.ts
+++ b/src/lib/post-detail-cache.ts
@@ -92,7 +92,7 @@ function revalidatePostDetailTag(tag: string) {
       return
     }
 
-    throw error
+    console.warn("[cache] post detail revalidation skipped", error)
   }
 }
 

--- a/src/lib/taxonomy-cache.ts
+++ b/src/lib/taxonomy-cache.ts
@@ -26,7 +26,7 @@ function revalidateTaxonomyTag(tag: string, profile: "max" | { expire: 0 }) {
       return
     }
 
-    throw error
+    console.warn("[cache] taxonomy revalidation skipped", error)
   }
 }
 

--- a/src/lib/user-surface.ts
+++ b/src/lib/user-surface.ts
@@ -149,6 +149,10 @@ export function revalidateUserSurfaceCache(userId?: number | null) {
       return
     }
 
-    throw error
+    // Cache invalidation is best effort. The database mutation that triggered
+    // it has already committed, so a cache adapter failure must not turn a
+    // successful user action into a false 500 response. The short TTL above
+    // still guarantees eventual freshness.
+    console.warn("[cache] user surface revalidation skipped", error)
   }
 }


### PR DESCRIPTION
## Summary
- refresh App Router server surfaces after successful badge, like, follow, favorite, tip, and block mutations
- keep the local interaction state and server-rendered surfaces consistent without a full browser reload
- treat post-mutation cache invalidation as best effort so a committed database mutation is not reported as a false 500 when a cache adapter is unavailable

## Verification
- targeted ESLint passed for all changed files
- `git diff --check` passed

## Scope
This change is framework-level and contains no site-specific branding, deployment, or credentials.