### PR TITLE
fix: let FAQ navigation scroll with page

### DIFF
--- a/src/components/faq-page-frame.tsx
+++ b/src/components/faq-page-frame.tsx
@@ -30,7 +30,7 @@ export function FaqPageFrame({ currentPath, children }: FaqPageFrameProps) {
         <>
           <AddonSlotRenderer slot="faq.tabs.before" />
           <AddonSurfaceRenderer surface="faq.tabs" props={{ currentPath }}>
-            <div className="sticky top-20 z-10 pb-1">
+            <div className="pb-1">
               <div className="overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
                 <div className="inline-flex min-w-max gap-2 rounded-xl border border-border bg-card p-2 shadow-xs md:flex md:min-w-0 md:flex-wrap">
                   {FAQ_TABS.map((tab) => (

--- a/test/faq-navigation-scroll.test.ts
+++ b/test/faq-navigation-scroll.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+test("FAQ navigation remains in normal document flow", async () => {
+  const source = await readFile("src/components/faq-page-frame.tsx", "utf8")
+
+  assert.doesNotMatch(source, /className=\"sticky top-20 z-10 pb-1\"/)
+  assert.match(source, /className=\"pb-1\"/)
+})


### PR DESCRIPTION
## Summary
- remove the sticky positioning from the shared FAQ navigation frame
- let the FAQ navigation leave the viewport naturally as the page scrolls
- add a regression test covering the normal document-flow behavior

## Verification
- focused FAQ navigation test passed
- targeted ESLint passed
- `git diff --check` passed

## Reproduction
The previous `sticky top-20` class kept the FAQ tabs fixed below the site header while the page content moved underneath them. Normal page navigation should scroll away with the document.